### PR TITLE
build: fix dependency-checks rule - ignore vite.config.ts and *.mocks.ts

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -34,7 +34,9 @@
       "default",
       "!{projectRoot}/.eslintrc.json",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
-      "!{projectRoot}/tsconfig.spec.json"
+      "!{projectRoot}/**/?(*.)mock.[jt]s?(x)",
+      "!{projectRoot}/tsconfig.spec.json",
+      "!{projectRoot}/vite.config.[jt]s"
     ],
     "sharedGlobals": []
   },

--- a/packages/cli/.eslintrc.json
+++ b/packages/cli/.eslintrc.json
@@ -18,12 +18,7 @@
       "files": ["*.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
-        "@nx/dependency-checks": [
-          "error",
-          {
-            "ignoredDependencies": ["vite", "vitest", "@nx/vite"]
-          }
-        ]
+        "@nx/dependency-checks": ["error"]
       }
     }
   ]

--- a/packages/models/.eslintrc.json
+++ b/packages/models/.eslintrc.json
@@ -18,12 +18,7 @@
       "files": ["*.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
-        "@nx/dependency-checks": [
-          "error",
-          {
-            "ignoredDependencies": ["vite", "vitest", "@nx/vite"]
-          }
-        ]
+        "@nx/dependency-checks": ["error"]
       }
     }
   ]

--- a/packages/plugin-eslint/.eslintrc.json
+++ b/packages/plugin-eslint/.eslintrc.json
@@ -18,10 +18,7 @@
       "files": ["*.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
-        "@nx/dependency-checks": [
-          "error",
-          { "ignoredDependencies": ["vite", "@nx/vite"] }
-        ]
+        "@nx/dependency-checks": ["error"]
       }
     }
   ]

--- a/packages/plugin-lighthouse/.eslintrc.json
+++ b/packages/plugin-lighthouse/.eslintrc.json
@@ -18,10 +18,7 @@
       "files": ["*.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
-        "@nx/dependency-checks": [
-          "error",
-          { "ignoredDependencies": ["vite", "@nx/vite"] }
-        ]
+        "@nx/dependency-checks": ["error"]
       }
     }
   ]

--- a/packages/utils/.eslintrc.json
+++ b/packages/utils/.eslintrc.json
@@ -18,12 +18,7 @@
       "files": ["*.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
-        "@nx/dependency-checks": [
-          "error",
-          {
-            "ignoredDependencies": ["vite", "vitest", "@nx/vite"]
-          }
-        ]
+        "@nx/dependency-checks": ["error"]
       }
     }
   ]


### PR DESCRIPTION
Workaround with `ignoredDependencies` for `@nx/dependency-checks` ESLint rule is now no longer needed :slightly_smiling_face: 