### PR TITLE
ci(testing): run tests on all major platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     name: Unit tests
     runs-on: ${{ matrix.os }}
     steps:
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     name: E2E tests
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Unit test affected projects
-        run: npx nx affected:test --parallel=3
+        uses: Wandalen/wretry.action@master
+        with:
+          command: npx nx affected:test --parallel=3
+          attempt_limit: 2
 
   e2e:
     strategy:
@@ -106,7 +109,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: E2E test affected projects
-        run: npx nx affected:e2e --parallel=3
+        uses: Wandalen/wretry.action@master
+        with:
+          command: npx nx affected:e2e --parallel=3
+          attempt_limit: 2
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,12 @@ jobs:
         run: npx nx affected:lint --parallel=3 --max-warnings=0
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     name: Unit tests
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -81,8 +85,12 @@ jobs:
         run: npx nx affected:test --parallel=3
 
   e2e:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     name: E2E tests
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/e2e/cli-e2e/vite.config.ts
+++ b/e2e/cli-e2e/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   // },
 
   test: {
-    testTimeout: 7000,
+    testTimeout: 20000,
     globals: true,
     cache: {
       dir: '../../node_modules/.vitest',


### PR DESCRIPTION
In this PR, I add matrix for running both unit and E2E tests on all three major platforms (Linux, Windows, MacOS).
- All jobs should run in parallel, so having all three platforms covered should not have any drawbacks.
- Even if one job fails, the other tests are executed.
- Timeout for E2E is increased due to slower execution in pipelines (mainly Windows).
- Unfortunately, the tests are currently flaky. I added one retry until this issue is resolved.