### PR TITLE
test(cli): fix progress bar config

### DIFF
--- a/packages/cli/src/lib/yargs-cli.spec.ts
+++ b/packages/cli/src/lib/yargs-cli.spec.ts
@@ -55,7 +55,7 @@ describe('yargsCli', () => {
         '..',
         '..',
         'test',
-        'cli-parsing.config.ts',
+        'cli-parsing.config.mock.ts',
       ),
       verbose: true,
       progress: false,

--- a/packages/cli/test/cli-parsing.config.mock.ts
+++ b/packages/cli/test/cli-parsing.config.mock.ts
@@ -1,12 +1,13 @@
 import { join } from 'path';
 import { CoreConfig } from '@code-pushup/models';
+import { echoRunnerConfig } from '../../models/test';
 
 /**
  * This config is here to test CLI arguments parsing e.g. `--verbose` or `--format=md stdout`
  * as well as the config file parsing, the content of this file
  *
  * Usage:
- * npx ./dist/packages/cli collect --config=./packages/cli/test/cli-parsing.config.ts
+ * npx ./dist/packages/cli collect --config=./packages/cli/test/cli-parsing.config.mock.ts
  */
 
 const outputDir = 'tmp';
@@ -33,23 +34,18 @@ export default {
           docsUrl: 'http://www.my-docs.dev',
         },
       ],
-      runner: {
-        command: 'echo',
-        args: [
-          `${JSON.stringify([
-            {
-              slug: 'audit-1',
-              title: 'audit title',
-              description: 'audit description',
-              docsUrl: 'http://www.my-docs.dev',
-              value: 350,
-              score: 68,
-              displayValue: '350ms',
-            },
-          ])} > ${outputFile}`,
+      runner: echoRunnerConfig(
+        [
+          {
+            slug: 'audit-1',
+            value: 350,
+            score: 0.68,
+            displayValue: '350ms',
+          },
         ],
         outputFile,
-      },
+      ),
+
       groups: [],
       slug: 'command-object-plugin',
       title: 'command-object plugin',


### PR DESCRIPTION
In this PR, I fixed the following:
- The score was transformed to 0-1 range
- JSON formatting was handled for Linux via `echoRunnerConfig`
- I removed metadata fields which caused type inconsistencies