### PR TITLE
chore: apply different commitlint plugin for imperative tense

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,7 +6,7 @@ const {
 /** @type {import('@commitlint/types').UserConfig} */
 const configuration = {
   extends: ['@commitlint/config-conventional'],
-  plugins: ['@ngx-devs/commitlint-plugin-imperative'],
+  plugins: ['commitlint-plugin-tense'],
   rules: {
     'scope-enum': async ctx => {
       const projects = await getProjects(
@@ -17,7 +17,11 @@ const configuration = {
       const scopes = [...projects, 'tools', 'workflows', 'testing'].sort();
       return [RuleConfigSeverity.Error, 'always', scopes];
     },
-    'imperative-rule/en': [RuleConfigSeverity.Error, 'always'],
+    'tense/subject-tense': [
+      RuleConfigSeverity.Error,
+      'always',
+      { firstOnly: true, allowedTenses: ['present-imperative'] },
+    ],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@commitlint/config-conventional": "^17.7.0",
         "@commitlint/config-nx-scopes": "^17.6.4",
         "@commitlint/cz-commitlint": "^17.7.1",
-        "@ngx-devs/commitlint-plugin-imperative": "^1.1.4",
         "@nx/devkit": "^16.8.1",
         "@nx/esbuild": "16.7.4",
         "@nx/eslint-plugin": "16.7.4",
@@ -50,6 +49,7 @@
         "@vitest/ui": "~0.32.0",
         "benchmark": "^2.1.4",
         "commitizen": "^4.3.0",
+        "commitlint-plugin-tense": "^1.0.2",
         "dotenv": "^16.3.1",
         "esbuild": "^0.17.17",
         "eslint": "~8.46.0",
@@ -3266,15 +3266,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@ngx-devs/commitlint-plugin-imperative": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@ngx-devs/commitlint-plugin-imperative/-/commitlint-plugin-imperative-1.1.4.tgz",
-      "integrity": "sha512-HktFA+kg0fEWc6eLhNUDgN1gZnDsKxUyiKD+tv5QQyw2LhKdIdi5RLdITdtIse9rFHhDycPff+mxAFSEHigZ6A==",
-      "dev": true,
-      "peerDependencies": {
-        "@commitlint/lint": ">=7.6.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8488,6 +8479,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/commitlint-plugin-tense": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/commitlint-plugin-tense/-/commitlint-plugin-tense-1.0.2.tgz",
+      "integrity": "sha512-pCD0qX+cQuE3jIVOeFu2fZmMbSBef2HnL1bQcFx+hwE6vmn8D0FZbeC6BulCos5lrlP96iLJSR2bBkABnzUSeg==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/message": "^16.2.1",
+        "fast-tag-pos": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      },
+      "peerDependencies": {
+        "@commitlint/lint": ">=7.6.0"
+      }
+    },
+    "node_modules/commitlint-plugin-tense/node_modules/@commitlint/message": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-16.2.1.tgz",
+      "integrity": "sha512-2eWX/47rftViYg7a3axYDdrgwKv32mxbycBJT6OQY/MJM7SUfYNYYvbMFOQFaA4xIVZt7t2Alyqslbl6blVwWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=v12"
+      }
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "dev": true,
@@ -10880,6 +10896,15 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-tag-pos": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-tag-pos/-/fast-tag-pos-2.0.0.tgz",
+      "integrity": "sha512-BdT2WMan25s8x5obDInSy1twqAKzeqHQ7T6fbowICcIUANoCRlhWUPn1e7r4Me2Jz3tNFT71MIZf2hIn0tUrag==",
+      "dev": true,
+      "engines": {
+        "node": ">=0"
+      }
     },
     "node_modules/fastq": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@commitlint/config-conventional": "^17.7.0",
     "@commitlint/config-nx-scopes": "^17.6.4",
     "@commitlint/cz-commitlint": "^17.7.1",
-    "@ngx-devs/commitlint-plugin-imperative": "^1.1.4",
+    "commitlint-plugin-tense": "^1.0.2",
     "@nx/devkit": "^16.8.1",
     "@nx/esbuild": "16.7.4",
     "@nx/eslint-plugin": "16.7.4",


### PR DESCRIPTION
I researched different plugins for commitlint as the current one produced false positives.
The `commitlint-plugin-tense` has the `firstOnly` option and a better recognition of nouns and adjectives that sound like verbs.
Docs [here](https://github.com/actuallydamo/commitlint-plugin-tense).

## Past tense examples
![image](https://github.com/flowup/quality-metrics-cli/assets/6306671/8b3bca02-63b1-46d4-997f-6d6c49ca8ffb)

## Present continuous examples
![image](https://github.com/flowup/quality-metrics-cli/assets/6306671/02cf3592-0895-43ea-9a86-099898968a72)
