### PR TITLE
refactor: fix lint errors

### DIFF
--- a/packages/plugin-eslint/src/lib/meta/groups.ts
+++ b/packages/plugin-eslint/src/lib/meta/groups.ts
@@ -54,6 +54,8 @@ export function groupsFromRuleTypes(rules: RuleData[]): AuditGroup[] {
 export function groupsFromRuleCategories(rules: RuleData[]): AuditGroup[] {
   const categoriesMap = rules.reduce<Record<string, Record<string, string[]>>>(
     (acc, { meta: { docs }, ruleId, options }) => {
+      // meta.docs.category still used by some popular plugins (e.g. import, react, functional)
+      // eslint-disable-next-line deprecation/deprecation
       const category = docs?.category;
       if (!category) {
         return acc;

--- a/packages/utils/src/lib/report-to-md.ts
+++ b/packages/utils/src/lib/report-to-md.ts
@@ -155,7 +155,7 @@ function groupRefItemToCategorySection(
   const groupTitle = li(
     `${getRoundScoreMarker(groupScore)} ${group.title} (_${plugin.title}_)`,
   );
-  const foundAudits = group.refs.reduce((acc, ref) => {
+  const foundAudits = group.refs.reduce<AuditReport[]>((acc, ref) => {
     const audit = plugin?.audits.find(
       ({ slug: auditSlugInPluginAudits }) =>
         auditSlugInPluginAudits === ref.slug,
@@ -165,7 +165,7 @@ function groupRefItemToCategorySection(
     }
 
     return acc;
-  }, [] as AuditReport[]);
+  }, []);
 
   const groupAudits = foundAudits.reduce((acc, audit) => {
     const auditTitle = link(


### PR DESCRIPTION
PRs #196 and #201 were merged just before #198, which is why the lint errors weren't caught by CI.

[Failing lint job](https://github.com/flowup/quality-metrics-cli/actions/runs/6770668535/job/18400058371).