### PR TITLE
build: add lint rules from eslint-plugin-n, disable no-sync temporarily

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,7 +61,7 @@
         "plugin:deprecation/recommended",
         "plugin:promise/recommended"
       ],
-      "plugins": ["functional", "no-secrets"],
+      "plugins": ["n", "functional", "no-secrets"],
       "settings": {
         "import/resolver": {
           "typescript": {
@@ -140,6 +140,10 @@
         "prefer-template": "warn",
         "radix": "warn",
         "yoda": "warn",
+        "n/no-unsupported-features/node-builtins": "error",
+        "n/no-process-exit": "warn",
+        "n/no-sync": "warn",
+        "n/prefer-promises/fs": "warn",
         "no-secrets/no-secrets": [
           "error",
           { "additionalDelimiters": ["-"], "ignoreContent": "https://" }
@@ -292,6 +296,7 @@
         "arrow-body-style": "off",
         "curly": "off",
         "no-duplicate-imports": "off",
+        "n/no-sync": "off",
         "functional/immutable-data": "off",
         "functional/no-let": "off",
         "import/no-useless-path-segments": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-functional": "^6.0.0",
         "eslint-plugin-import": "2.27.5",
         "eslint-plugin-jsx-a11y": "6.7.1",
+        "eslint-plugin-n": "^16.3.1",
         "eslint-plugin-no-secrets": "^0.8.9",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.33.2",
@@ -7899,6 +7900,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "4.0.1",
       "license": "MIT",
@@ -10264,6 +10274,25 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.3.0.tgz",
+      "integrity": "sha512-W9zIs+k00I/I13+Bdkl/zG1MEO07G97XjUSQuH117w620SJ6bHtLUmoMvkGA2oYnI/gNdr+G7BONLyYnFaLLEQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
     "node_modules/eslint-plugin-functional": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-6.0.0.tgz",
@@ -10554,6 +10583,45 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
+      "integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.1.0",
+        "get-tsconfig": "^4.7.0",
+        "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-no-secrets": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-functional": "^6.0.0",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jsx-a11y": "6.7.1",
+    "eslint-plugin-n": "^16.3.1",
     "eslint-plugin-no-secrets": "^0.8.9",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.33.2",


### PR DESCRIPTION
Added the following rules from [esling-plugin-n](https://github.com/eslint-community/eslint-plugin-n#readme):
- [no-sync](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-sync.md) - 27 warnings (see screenshot) :arrow_right: disabled in `lint` for now, but will be tracked by Code PushUp
  - arguments for always using promises with `fs`:
    - non-blocking - e.g. if we have a spinner in the terminal, then it should be smooth regardless of what file operations are happening
    - easier to parallelize (`Promise.all`, `Promise.allSettled`)
    - we have top-level await thanks to ESM, all tests and hooks can be `async` ... we don't really have a reason to use the sync version
- [prefer-promises/fs](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/prefer-promises/fs.md) - 0 warnings
- [no-process-exit](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-process-exit.md) - 0 warnings 
- [no-unsupported-features/node-builtins](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-unsupported-features/node-builtins.md) - 0 errors


![Screenshot from 2023-11-10 17-55-58](https://github.com/flowup/quality-metrics-cli/assets/34691111/06a84ad3-adc8-4859-8f2f-2e5e1d359de3)
