### PR TITLE
refactor(utils): relocate report logic

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -18,7 +18,6 @@ export {
   compareIssueSeverity,
   formatBytes,
   formatCount,
-  slugify,
   loadReport,
 } from './lib/report';
 export { reportToMd } from './lib/report-to-md';
@@ -38,5 +37,6 @@ export {
   FileResult,
   MultipleFileResults,
   logMultipleFileResults,
+  slugify,
 } from './lib/utils';
 export { verboseUtils } from './lib/verbose-utils';

--- a/packages/utils/src/lib/report-to-md.ts
+++ b/packages/utils/src/lib/report-to-md.ts
@@ -31,9 +31,9 @@ import {
   reportHeadlineText,
   reportMetaTableHeaders,
   reportOverviewTableHeaders,
-  slugify,
 } from './report';
 import { EnrichedScoredAuditGroup, ScoredReport } from './scoring';
+import { slugify } from './utils';
 
 export function reportToMd(
   report: ScoredReport,

--- a/packages/utils/src/lib/report-to-md.ts
+++ b/packages/utils/src/lib/report-to-md.ts
@@ -21,12 +21,8 @@ import {
   FOOTER_PREFIX,
   README_LINK,
   countCategoryAudits,
-  formatDuration,
-  slugify,
-} from './report';
-import { EnrichedScoredAuditGroup, ScoredReport } from './scoring';
-import {
   detailsTableHeaders,
+  formatDuration,
   formatReportScore,
   getRoundScoreMarker,
   getSeverityIcon,
@@ -35,7 +31,9 @@ import {
   reportHeadlineText,
   reportMetaTableHeaders,
   reportOverviewTableHeaders,
-} from './utils';
+  slugify,
+} from './report';
+import { EnrichedScoredAuditGroup, ScoredReport } from './scoring';
 
 export function reportToMd(
   report: ScoredReport,

--- a/packages/utils/src/lib/report-to-stdout.ts
+++ b/packages/utils/src/lib/report-to-stdout.ts
@@ -1,9 +1,14 @@
 import chalk from 'chalk';
 import cliui from 'cliui';
 import { NEW_LINE } from './md';
-import { CODE_PUSHUP_DOMAIN, FOOTER_PREFIX, countWeightedRefs } from './report';
+import {
+  CODE_PUSHUP_DOMAIN,
+  FOOTER_PREFIX,
+  countWeightedRefs,
+  reportHeadlineText,
+  reportOverviewTableHeaders,
+} from './report';
 import { ScoredReport } from './scoring';
-import { reportHeadlineText, reportOverviewTableHeaders } from './utils';
 
 const ui = cliui({ width: 60 }); // @TODO check display width
 

--- a/packages/utils/src/lib/report.spec.ts
+++ b/packages/utils/src/lib/report.spec.ts
@@ -9,7 +9,6 @@ import {
   formatBytes,
   formatCount,
   loadReport,
-  slugify,
 } from './report';
 
 // Mock file system API's
@@ -28,19 +27,6 @@ const resetFiles = (files?: Record<string, string>) => {
   vol.reset();
   vol.fromJSON(files || {}, outputDir);
 };
-
-describe('slugify', () => {
-  it.each([
-    ['Largest Contentful Paint', 'largest-contentful-paint'],
-    ['cumulative-layout-shift', 'cumulative-layout-shift'],
-    ['max-lines-200', 'max-lines-200'],
-    ['rxjs/finnish', 'rxjs-finnish'],
-    ['@typescript-eslint/no-explicit-any', 'typescript-eslint-no-explicit-any'],
-    ['Code  PushUp ', 'code-pushup'],
-  ])('should transform "%s" to valid slug "%s"', (text, slug) => {
-    expect(slugify(text)).toBe(slug);
-  });
-});
 
 describe('formatBytes', () => {
   it('should log file sizes in Bytes`', async () => {

--- a/packages/utils/src/lib/report.ts
+++ b/packages/utils/src/lib/report.ts
@@ -19,13 +19,71 @@ export const FOOTER_PREFIX = 'Made with ❤️ by';
 export const CODE_PUSHUP_DOMAIN = 'code-pushup.dev';
 export const README_LINK =
   'https://github.com/flowup/quality-metrics-cli#readme';
+export const reportHeadlineText = 'Code PushUp Report';
+export const reportOverviewTableHeaders = [
+  '🏷 Category',
+  '⭐ Score',
+  '🛡 Audits',
+];
+export const reportMetaTableHeaders: string[] = [
+  'Commit',
+  'Version',
+  'Duration',
+  'Plugins',
+  'Categories',
+  'Audits',
+];
 
-export function slugify(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/\s+|\//g, '-')
-    .replace(/[^a-z0-9-]/g, '');
+export const pluginMetaTableHeaders: string[] = [
+  'Plugin',
+  'Audits',
+  'Version',
+  'Duration',
+];
+
+// details headers
+
+export const detailsTableHeaders: string[] = [
+  'Severity',
+  'Message',
+  'Source file',
+  'Line(s)',
+];
+
+export function formatReportScore(score: number): string {
+  return Math.round(score * 100).toString();
+}
+
+export function getRoundScoreMarker(score: number): string {
+  if (score >= 0.9) {
+    return '🟢';
+  }
+  if (score >= 0.5) {
+    return '🟡';
+  }
+  return '🔴';
+}
+
+export function getSquaredScoreMarker(score: number): string {
+  if (score >= 0.9) {
+    return '🟩';
+  }
+  if (score >= 0.5) {
+    return '🟨';
+  }
+  return '🟥';
+}
+
+export function getSeverityIcon(
+  severity: 'info' | 'warning' | 'error',
+): string {
+  if (severity === 'error') {
+    return '🚨';
+  }
+  if (severity === 'warning') {
+    return '⚠️';
+  }
+  return 'ℹ️';
 }
 
 export function formatBytes(bytes: number, decimals = 2) {

--- a/packages/utils/src/lib/utils.spec.ts
+++ b/packages/utils/src/lib/utils.spec.ts
@@ -10,10 +10,10 @@ import {
   ensureDirectoryExists,
   logMultipleFileResults,
   pluralize,
+  slugify,
   toArray,
   toUnixPath,
 } from './utils';
-import { slugify } from './utils';
 
 // Mock file system API's
 vi.mock('fs', async () => {

--- a/packages/utils/src/lib/utils.spec.ts
+++ b/packages/utils/src/lib/utils.spec.ts
@@ -13,6 +13,7 @@ import {
   toArray,
   toUnixPath,
 } from './utils';
+import { slugify } from './utils';
 
 // Mock file system API's
 vi.mock('fs', async () => {
@@ -25,6 +26,19 @@ vi.mock('fs/promises', async () => {
 });
 
 const outputDir = MEMFS_VOLUME;
+
+describe('slugify', () => {
+  it.each([
+    ['Largest Contentful Paint', 'largest-contentful-paint'],
+    ['cumulative-layout-shift', 'cumulative-layout-shift'],
+    ['max-lines-200', 'max-lines-200'],
+    ['rxjs/finnish', 'rxjs-finnish'],
+    ['@typescript-eslint/no-explicit-any', 'typescript-eslint-no-explicit-any'],
+    ['Code  PushUp ', 'code-pushup'],
+  ])('should transform "%s" to valid slug "%s"', (text, slug) => {
+    expect(slugify(text)).toBe(slug);
+  });
+});
 
 describe('pluralize', () => {
   it.each([

--- a/packages/utils/src/lib/utils.ts
+++ b/packages/utils/src/lib/utils.ts
@@ -2,39 +2,15 @@ import chalk from 'chalk';
 import { mkdir, readFile } from 'fs/promises';
 import { formatBytes } from './report';
 
-// @TODO move logic out of this file as much as possible. use report.ts or scoring.ts instead.
-export const reportHeadlineText = 'Code PushUp Report';
-export const reportOverviewTableHeaders = [
-  '🏷 Category',
-  '⭐ Score',
-  '🛡 Audits',
-];
-export const reportMetaTableHeaders: string[] = [
-  'Commit',
-  'Version',
-  'Duration',
-  'Plugins',
-  'Categories',
-  'Audits',
-];
-
-export const pluginMetaTableHeaders: string[] = [
-  'Plugin',
-  'Audits',
-  'Version',
-  'Duration',
-];
-
-// details headers
-
-export const detailsTableHeaders: string[] = [
-  'Severity',
-  'Message',
-  'Source file',
-  'Line(s)',
-];
-
 // === Transform
+
+export function slugify(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/\s+|\//g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+}
 
 export function pluralize(text: string): string {
   if (text.endsWith('y')) {
@@ -69,45 +45,6 @@ export function countOccurrences<T extends PropertyKey>(
 
 export function distinct<T extends string | number | boolean>(array: T[]): T[] {
   return Array.from(new Set(array));
-}
-
-// @TODO move to report.ts
-export function formatReportScore(score: number): string {
-  return Math.round(score * 100).toString();
-}
-
-// === Markdown @TODO move to report-to-md.ts
-
-export function getRoundScoreMarker(score: number): string {
-  if (score >= 0.9) {
-    return '🟢';
-  }
-  if (score >= 0.5) {
-    return '🟡';
-  }
-  return '🔴';
-}
-
-export function getSquaredScoreMarker(score: number): string {
-  if (score >= 0.9) {
-    return '🟩';
-  }
-  if (score >= 0.5) {
-    return '🟨';
-  }
-  return '🟥';
-}
-
-export function getSeverityIcon(
-  severity: 'info' | 'warning' | 'error',
-): string {
-  if (severity === 'error') {
-    return '🚨';
-  }
-  if (severity === 'warning') {
-    return '⚠️';
-  }
-  return 'ℹ️';
 }
 
 // === Filesystem @TODO move to fs-utils.ts


### PR DESCRIPTION
This PR moves report related logic and moves `slugify` back into `utils.ts`. This file will undergo more refactoring in followup PRs.

There is on open ticket for this PR, but the scope is tiny and the change is very reasonable to to now.